### PR TITLE
bug fixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 1.4.1
+* Bug fixing
+
 #### 1.4.0
 * Adding self-service onboarding feature
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Requires at least: `4.0`
 
 Tested up to: `4.9.7`
 
-Stable tag: `1.4.0`
+Stable tag: `1.4.1`
 
 License: `MIT`
 

--- a/trusona-openid.php
+++ b/trusona-openid.php
@@ -296,7 +296,7 @@ class TrusonaOpenID
             if (count($users) > 0) {
                 list($is_admin, $user) = $this->has_admin($users);
                 $subject = $user_claim[self::SUBJECT_KEY];
-                wp_set_auth_cookie($user->ID, false, false);
+                wp_set_auth_cookie($user->ID, false);
 
                 update_user_meta($user->ID, self::PLUGIN_ID_PREFIX . 'subject_id', $subject);
                 update_user_meta($user->ID, self::PLUGIN_ID_PREFIX . 'enabled', true);


### PR DESCRIPTION
fixing bug due to incorrect use of `wp_set_auth_cookie`

reference https://codex.wordpress.org/Function_Reference/wp_set_auth_cookie

the use of `false` as the 3rd parameter is not allowed in version PHP 7

should have been `''` (a blank)