### PR TITLE
Fixed some bugs and added instructions for HTTP CSP header configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!*.php
+!*.txt
+!includes
+!css

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,4 @@ FROM wordpress:php5.6
 ENV PLUGINS_DIR /usr/src/wordpress/wp-content/plugins
 RUN mkdir $PLUGINS_DIR/trusona
 
-ADD *.php $PLUGINS_DIR/trusona/
-ADD *.txt $PLUGINS_DIR/trusona/
-ADD includes $PLUGINS_DIR/trusona/includes
-ADD images $PLUGINS_DIR/trusona/images
-ADD css $PLUGINS_DIR/trusona/css
+COPY . $PLUGINS_DIR/trusona/

--- a/Dockerfile.php71
+++ b/Dockerfile.php71
@@ -3,8 +3,4 @@ FROM wordpress:php7.1
 ENV PLUGINS_DIR /usr/src/wordpress/wp-content/plugins
 RUN mkdir $PLUGINS_DIR/trusona
 
-ADD *.php $PLUGINS_DIR/trusona/
-ADD *.txt $PLUGINS_DIR/trusona/
-ADD includes $PLUGINS_DIR/trusona/includes
-ADD images $PLUGINS_DIR/trusona/images
-ADD css $PLUGINS_DIR/trusona/css
+COPY . $PLUGINS_DIR/trusona/

--- a/css/trusona-openid.css
+++ b/css/trusona-openid.css
@@ -1,14 +1,3 @@
-div#login_error {
-    width: 100%;
-}
-
-.login_center {
-  position: absolute;
-  left: 50%;
-  top: 20%;
-  transform: translate(-50%, -50%); /* Yep! */
-}
-
 .underline {
     text-decoration: underline;
 }

--- a/includes/trusona-functions.php
+++ b/includes/trusona-functions.php
@@ -25,8 +25,8 @@ function trusona_custom_login($url, $allow_wp_form)
     }
 
     if ($allow_wp_form) {
-        $data .= '<div style="text-align: center;"><br/><script>jQuery(document).ready(function() { jQuery(\'#login\').width(\'350px\').addClass(\'login_center\'); });</script>';
-        $data .= '<a href="#" style="font-size:smaller;color:#c0c0c0;" onclick="jQuery(\'form > p\').toggle();jQuery(\'.user-pass-wrap\').toggle();jQuery(\'#user_pass\').prop(\'disabled\',false);this.blur();return false;">Toggle Classic Login</a></div><br/>';
+        $data .= '<div style="text-align: center;"><br/><script>jQuery(document).ready(function() { jQuery(\'#login\').width(\'350px\'); });</script>';
+        $data .= '<a href="#" class="button-secondary" onclick="jQuery(\'form > p\').toggle();jQuery(\'.user-pass-wrap\').toggle();jQuery(\'#user_pass\').prop(\'disabled\',false);this.blur();return false;">Toggle Classic Login</a></div><br/>';
     }
 
     $data .= '</div>';

--- a/trusona-openid.php
+++ b/trusona-openid.php
@@ -386,35 +386,37 @@ class TrusonaOpenID
     {
         echo '<div class="wrap">';
         screen_icon();
-        echo '<table class="form-table"><tbody>';
+        echo '<h1>Trusona WordPress Settings</h1>';
+        echo '<h2 class="title" style="margin-top: 2em;">Important info</h2>';
+        echo '<p>If you are using HTTP Content Security Policy (CSP), note that you must add <code>https://static.trusona.net</code> to the <code>style-src</code> and <code>img-src</code> directives in order for the <span style="font-weight: bolder;">Login with Trusona</span> button to have the desired design.</p>';
+        echo '<p>For more information, see the introductory article on <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP" target="_blank" aria-label="Read more about HTTP Content-Security-Policy">Content Security Policy (CSP)</a>.</p>';
+
         echo '<form method="post" action="options.php">';
         settings_fields('trusona_options_group');
-        do_settings_sections('trusona-admin-settings');
+        echo '<h2 class="title" style="margin-top: 2em;">Trusona Settings</h2>';
+        echo '<table class="form-table" role="presentation"><tbody>';
 
-        echo '<tr><td style="vertical-align: top;" width="2em">';
+        echo '<tr><th scope="row">Login only with Trusona</th><td>';
+        echo '<fieldset><legend class="screen-reader-text"><span>Login only with Trusona</span></legend><label for="disable_wp_form">';
         $this->print_bool_field('disable_wp_form');
-        echo '</td><td>Trusona ONLY Mode <br/><br/>';
-        echo '<span style="font-size: smaller;">';
-        echo '<span style="color: red; font-weight: bolder;">WARNING!</span>&nbsp;';
-        echo 'By checking this box, you disable the ability to toggle between <span style="font-weight: bolder;">Login with Trusona</span> and username and passwords.<br/>';
-        echo 'You should make this selection ONLY if you have access to the WP server independent of the login page, as otherwise you <br/>are blocking all other options to login.';
-        echo '</span></td></tr>';
-
-        echo '<tr><td style="vertical-align: top;" width="2em">';
-        $this->print_bool_field('self_service_onboarding');
-        echo '</td><td>Self-Service Account Creation<br/><br/>';
-        echo '<span style="font-size: smaller;">';
-        echo '<span style="color: red; font-weight: bolder;">WARNING!</span>&nbsp;';
-        echo 'By checking this box, you allow the Trusona plugin to create basic (subscriber) accounts for your WordPress site if an <br/>';
-        echo 'account is not found for that Trusona user - thus allowing for a true <span style="font-weight: bolder;">#NoPasswords</span> experience!<br/>';
-
-        echo '</span></td></tr>';
-        echo '<tr><td colspan="2">';
-        submit_button();
+	echo 'Trusona ONLY Mode</label></fieldset>';
+        echo '<p class="description"><span style="color: red; font-weight: bolder;">WARNING!</span> By checking this box, you disable the ability to toggle between <span style="font-weight: bolder;">Login with Trusona</span> and username and passwords. You should make this selection ONLY if you have access to the WP server independent of the login page, as otherwise you are blocking all other options to login.</p>';
         echo '</td></tr>';
-        echo '<tr><td style="color: #c0c0c0; font-size: smaller;" colspan="2">PHP ' . phpversion();
-        echo '<br/>WordPress ' . get_bloginfo('version') . '</td></tr>';
-        echo '</form></tbody></table></div>';
+
+        echo '<tr><th scope="row">Membership</th><td>';
+        echo '<fieldset><legend class="screen-reader-text"><span>Membership</span></legend><label for="self_service_onboarding">';
+        $this->print_bool_field('self_service_onboarding');
+	echo 'Self-Service Account Creation</label></fieldset>';
+        echo '<p class="description"><span style="color: red; font-weight: bolder;">WARNING!</span> By checking this box, you allow the Trusona plugin to create basic (subscriber) accounts for your WordPress site if an account is not found for that Trusona user - thus allowing for a true <span style="font-weight: bolder;">#NoPasswords</span> experience!</p>';
+        echo '</td></tr>';
+        echo '</tbody></table>';
+        submit_button();
+        echo '</form>';
+
+        echo '<h2 class="title" style="margin-top: 2em;">Debugging information</h2>';
+        echo '<p>PHP ' . phpversion() . '</p>';
+        echo '<p>WordPress ' . get_bloginfo('version') . '</p>';
+        echo '</div>';
     }
 
     public function filter_plugin_actions($links)


### PR DESCRIPTION
1. I have added information on how to configure the [HTTP Content Security Policy (CSP) header,](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) if used, so that the " Login with Trusona" button will be displayed correctly.
![image](https://user-images.githubusercontent.com/28236583/202723044-23937442-8671-46dd-9a1c-ff061b3f0a99.png)
2. I solved the problem below with creating Docker images.
![image](https://user-images.githubusercontent.com/28236583/202720084-c1eb4b5d-7a60-473d-8898-5be296f90ee6.png)
3. I solved the problem below with the wrong display of error messages.
![image](https://user-images.githubusercontent.com/28236583/202723190-c94f7607-32bf-480d-9ac7-920d82d1f731.png)
4. I have solved the accessibility issues below.
![image](https://user-images.githubusercontent.com/28236583/202722339-7ecbd87e-ddbe-43ac-85db-8337914f7769.png)
![image](https://user-images.githubusercontent.com/28236583/202725167-94788b8d-8846-4ab2-a55f-92c7c4681a68.png) 