### PR TITLE
Bind OpenID state/nonce to the browser (login CSRF fix); v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 2.0.3
+* **Security**
+  * Bind the OpenID `state` and `nonce` to the browser that initiated the login (server-side, single-use, HttpOnly cookie). This prevents login CSRF / forced authentication and replay of a captured authorization response — previously the `state`/`nonce` were generated but never validated on the callback.
+  * Validate the ID token `nonce` claim during login (`trusona_is_valid_jwt()` gained an optional expected-nonce argument).
+* **Maintenance**
+  * Removed the unused bundled `firebase/php-jwt` library from the plugin package (validation is handled by the plugin's own JWT functions).
+  * Repaired the unit test suite (function names, `ABSPATH` bootstrap) and bumped PHPUnit to `^9.6` for PHP 8.1; added coverage for nonce binding, wrong-secret, and malformed-token cases.
+
 ### 2.0.2
 * Fixed login page rendering unstyled when the default form is disabled (`wp_kses_post()` was stripping the page's stylesheets and scripts)
 

--- a/includes/jwt-functions.php
+++ b/includes/jwt-functions.php
@@ -51,7 +51,17 @@ function trusona_matches_issuer($payload) {
   return isset($payload->iss) && $payload->iss === ISSUER;
 }
 
-function trusona_is_valid_jwt($token, $secret)
+function trusona_matches_nonce($payload, $expected_nonce) {
+  if ($expected_nonce === null) { // nonce binding is optional
+    return true;
+  }
+
+  return isset($payload->nonce)
+    && is_string($payload->nonce)
+    && hash_equals((string) $expected_nonce, $payload->nonce);
+}
+
+function trusona_is_valid_jwt($token, $secret, $expected_nonce = null)
 {
   try {
     // Validate token format
@@ -82,7 +92,8 @@ function trusona_is_valid_jwt($token, $secret)
     // Use hash_equals for constant-time comparison
     return hash_equals($signature, $third)
       && trusona_not_expired($payload)
-      && trusona_matches_issuer($payload);
+      && trusona_matches_issuer($payload)
+      && trusona_matches_nonce($payload, $expected_nonce);
   }
   catch(Throwable $e) { // Catch Throwable for PHP 8 compatibility
     return false;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-  backupGlobals="false"
+  bootstrap="tests/bootstrap.php"
   colors="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
   >
   <testsuites>
     <testsuite name="unit">

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Trusona
 Tags: passwordless, mfa, 2fa, security, login
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 Requires PHP: 8.1
 License: MIT
 
@@ -91,6 +91,12 @@ No, at this moment, the plugin will not work with the WordPress REST API.
 5. Security that works is security that people don’t work around.
 
 == Changelog ==
+= 2.0.3
+* Security: bind the OpenID state and nonce to the browser that started the login, preventing login CSRF (forced authentication) and replay of a captured authorization response
+* Security: validate the ID token nonce claim during login
+* Removed the unused bundled firebase/php-jwt library from the plugin package
+* Repaired and expanded the unit test suite
+
 = 2.0.2
 * Fixed login page rendering unstyled when the default form is disabled (wp_kses_post() was stripping the page's stylesheets and scripts)
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+// PHPUnit bootstrap. The plugin's include files guard on ABSPATH and call a
+// handful of WordPress functions, so define the guard and load lightweight
+// shims before any test (or include) is loaded.
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+require_once __DIR__ . '/fixture-functions.php';

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,5 +1,5 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/tests/fixture-functions.php
+++ b/tests/fixture-functions.php
@@ -1,7 +1,18 @@
 <?php
 
-function home_url() {
-  return 'https://www.tacoshrimp.com/wp-admin?dipping_sauce=yesplease';
+// Minimal WordPress shims so the plugin's pure helper functions can be
+// exercised without a full WordPress runtime.
+
+if (!function_exists('home_url')) {
+    function home_url() {
+        return 'https://www.tacoshrimp.com/wp-admin?dipping_sauce=yesplease';
+    }
+}
+
+if (!function_exists('wp_parse_url')) {
+    function wp_parse_url($url, $component = -1) {
+        return parse_url($url, $component);
+    }
 }
 
 ?>

--- a/tests/test-jwt-functions.php
+++ b/tests/test-jwt-functions.php
@@ -6,22 +6,56 @@ use PHPUnit\Framework\TestCase;
 
 final class TestJwtFunctions extends TestCase
 {
+  const SECRET = 'ZxNgBxchmExqsoIqs57Xn3mciRtnVAumDSbSSkeden';
+
+  // Nonce claim embedded in the sample tokens below.
+  const TOKEN_NONCE = 'f3169ae582a4f2256e1383b4c280160c7c0a3c30';
+
+  const VALID_SHA512 = 'eyJhbGciOiJIUzUxMiJ9.eyJhdWQiOiI4MTBkNDU0Yy0xN2Y5LTQyYTItODFmYi0xMDYyOWQxNzhkOTAiLCJzdWIiOiI1YWFjMThmNy0wZTNiLTQwYWYtODJkMS1mYTYxMmE2Yzk2MWQiLCJ1cGRhdGVkX2F0IjoxNTYwODY4MTU0NDg1LCJpc3MiOiJpZHAudHJ1c29uYS5jb20iLCJleHAiOjE5NzY4MjEyMDg0MDQsImlhdCI6MTU3NjgxNzYwODQwNCwibm9uY2UiOiJmMzE2OWFlNTgyYTRmMjI1NmUxMzgzYjRjMjgwMTYwYzdjMGEzYzMwIn0.bIhUj7Sc68-IZGe3tzy--pKrXUaK1-t2CKsErGZ8AH6j6ZnVYQzh42ZDu4gp2kdgWRrX6tweEvUTYWin7M8vAQ';
+
+  const VALID_SHA256 = 'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI4MTBkNDU0Yy0xN2Y5LTQyYTItODFmYi0xMDYyOWQxNzhkOTAiLCJzdWIiOiI1YWFjMThmNy0wZTNiLTQwYWYtODJkMS1mYTYxMmE2Yzk2MWQiLCJ1cGRhdGVkX2F0IjoxNTYwODY4MTU0NDg1LCJpc3MiOiJpZHAudHJ1c29uYS5jb20iLCJleHAiOjE5NzY4MjEyMDg0MDQsImlhdCI6MTU3NjgxNzYwODQwNCwibm9uY2UiOiJmMzE2OWFlNTgyYTRmMjI1NmUxMzgzYjRjMjgwMTYwYzdjMGEzYzMwIn0.PCgH572c1aBHtAaTx6hjLNmTPLE6JuorlxGRsAuq_5U';
+
+  const EXPIRED = 'eyJhbGciOiJIUzUxMiJ9.eyJhdWQiOiI4MTBkNDU0Yy0xN2Y5LTQyYTItODFmYi0xMDYyOWQxNzhkOTAiLCJzdWIiOiI1YWFjMThmNy0wZTNiLTQwYWYtODJkMS1mYTYxMmE2Yzk2MWQiLCJ1cGRhdGVkX2F0IjoxNTYwODY4MTU0NDg1LCJpc3MiOiJpZHAudHJ1c29uYS5jb20iLCJleHAiOjE0NzY4MjEyMDg0MDQsImlhdCI6MTU3NjgxNzYwODQwNCwibm9uY2UiOiJmMzE2OWFlNTgyYTRmMjI1NmUxMzgzYjRjMjgwMTYwYzdjMGEzYzMwIn0.BGg_e-g2kPLh9cRv6bV_UfJPx1GYMIMr5rpvfvENi6rcvPonRxpf9jlUzDC6WJ0xoc3xb906jGpKrw2SadfrxQ';
+
   public function test_valid_token_sha512()
   {
-    $jwt = 'eyJhbGciOiJIUzUxMiJ9.eyJhdWQiOiI4MTBkNDU0Yy0xN2Y5LTQyYTItODFmYi0xMDYyOWQxNzhkOTAiLCJzdWIiOiI1YWFjMThmNy0wZTNiLTQwYWYtODJkMS1mYTYxMmE2Yzk2MWQiLCJ1cGRhdGVkX2F0IjoxNTYwODY4MTU0NDg1LCJpc3MiOiJpZHAudHJ1c29uYS5jb20iLCJleHAiOjE5NzY4MjEyMDg0MDQsImlhdCI6MTU3NjgxNzYwODQwNCwibm9uY2UiOiJmMzE2OWFlNTgyYTRmMjI1NmUxMzgzYjRjMjgwMTYwYzdjMGEzYzMwIn0.bIhUj7Sc68-IZGe3tzy--pKrXUaK1-t2CKsErGZ8AH6j6ZnVYQzh42ZDu4gp2kdgWRrX6tweEvUTYWin7M8vAQ';
-    $this->assertTrue(is_valid_jwt($jwt, 'ZxNgBxchmExqsoIqs57Xn3mciRtnVAumDSbSSkeden'));
+    $this->assertTrue(trusona_is_valid_jwt(self::VALID_SHA512, self::SECRET));
   }
 
   public function test_valid_token_sha256()
   {
-    $jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI4MTBkNDU0Yy0xN2Y5LTQyYTItODFmYi0xMDYyOWQxNzhkOTAiLCJzdWIiOiI1YWFjMThmNy0wZTNiLTQwYWYtODJkMS1mYTYxMmE2Yzk2MWQiLCJ1cGRhdGVkX2F0IjoxNTYwODY4MTU0NDg1LCJpc3MiOiJpZHAudHJ1c29uYS5jb20iLCJleHAiOjE5NzY4MjEyMDg0MDQsImlhdCI6MTU3NjgxNzYwODQwNCwibm9uY2UiOiJmMzE2OWFlNTgyYTRmMjI1NmUxMzgzYjRjMjgwMTYwYzdjMGEzYzMwIn0.PCgH572c1aBHtAaTx6hjLNmTPLE6JuorlxGRsAuq_5U';
-    $this->assertTrue(is_valid_jwt($jwt, 'ZxNgBxchmExqsoIqs57Xn3mciRtnVAumDSbSSkeden'));
+    $this->assertTrue(trusona_is_valid_jwt(self::VALID_SHA256, self::SECRET));
   }
 
   public function test_expired_token()
   {
-    $jwt = 'eyJhbGciOiJIUzUxMiJ9.eyJhdWQiOiI4MTBkNDU0Yy0xN2Y5LTQyYTItODFmYi0xMDYyOWQxNzhkOTAiLCJzdWIiOiI1YWFjMThmNy0wZTNiLTQwYWYtODJkMS1mYTYxMmE2Yzk2MWQiLCJ1cGRhdGVkX2F0IjoxNTYwODY4MTU0NDg1LCJpc3MiOiJpZHAudHJ1c29uYS5jb20iLCJleHAiOjE0NzY4MjEyMDg0MDQsImlhdCI6MTU3NjgxNzYwODQwNCwibm9uY2UiOiJmMzE2OWFlNTgyYTRmMjI1NmUxMzgzYjRjMjgwMTYwYzdjMGEzYzMwIn0.BGg_e-g2kPLh9cRv6bV_UfJPx1GYMIMr5rpvfvENi6rcvPonRxpf9jlUzDC6WJ0xoc3xb906jGpKrw2SadfrxQ';
-    $this->assertFalse(is_valid_jwt($jwt, 'ZxNgBxchmExqsoIqs57Xn3mciRtnVAumDSbSSkeden'));
+    $this->assertFalse(trusona_is_valid_jwt(self::EXPIRED, self::SECRET));
+  }
+
+  public function test_wrong_secret_is_rejected()
+  {
+    $this->assertFalse(trusona_is_valid_jwt(self::VALID_SHA256, 'not-the-secret'));
+  }
+
+  public function test_malformed_token_is_rejected()
+  {
+    $this->assertFalse(trusona_is_valid_jwt('not.a.jwt', self::SECRET));
+    $this->assertFalse(trusona_is_valid_jwt('only-two.parts', self::SECRET));
+  }
+
+  public function test_valid_token_with_matching_nonce()
+  {
+    $this->assertTrue(trusona_is_valid_jwt(self::VALID_SHA256, self::SECRET, self::TOKEN_NONCE));
+  }
+
+  public function test_valid_token_with_wrong_nonce_is_rejected()
+  {
+    $this->assertFalse(trusona_is_valid_jwt(self::VALID_SHA256, self::SECRET, 'a-different-nonce'));
+  }
+
+  public function test_nonce_binding_is_optional_when_null()
+  {
+    $this->assertTrue(trusona_is_valid_jwt(self::VALID_SHA256, self::SECRET, null));
   }
 }
 

--- a/tests/test-trusona-functions.php
+++ b/tests/test-trusona-functions.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once __DIR__ . '/fixture-functions.php';
 require_once __DIR__ . '/../includes/trusona-functions.php';
 
 use PHPUnit\Framework\TestCase;
@@ -9,14 +8,13 @@ final class TestTrusonaFunctions extends TestCase
 {
     public function test_is_production()
     {
-      $this->assertTrue(is_production('https://idp.trusona.com'));
-      $this->assertFalse(is_production('https://idp.staging.trusona.com'));
+      $this->assertTrue(trusona_is_production('https://idp.trusona.com'));
+      $this->assertFalse(trusona_is_production('https://idp.staging.trusona.com'));
     }
 
     public function test_compute_site_hash()
     {
-        $url = 'https://www.tacoshrimp.com/wp-admin?dipping_sauce=yesplease';
-        $this->assertEquals(compute_site_hash($url), sha1('www.tacoshrimp.com'));
+        $this->assertEquals(trusona_compute_site_hash(), sha1('www.tacoshrimp.com'));
     }
 }
 

--- a/trusona-openid.php
+++ b/trusona-openid.php
@@ -4,7 +4,7 @@
     Plugin Name: Trusona
     Plugin URI: https://wordpress.org/plugins/trusona/
     Description: Login to your WordPress with Trusona's FREE #NoPasswords plugin. This plugin requires the Trusona app. View details for installation instructions.
-    Version: 2.0.2
+    Version: 2.0.3
     Author: Trusona
     Author URI: https://trusona.com
     License: MIT
@@ -23,6 +23,9 @@ class TrusonaOpenID
     const PLUGIN_ID_PREFIX = 'trusona_openid_';
     const SCOPES           = 'openid email';
     const SUBJECT_KEY      = 'sub';
+
+    const FLOW_COOKIE      = 'trusona_openid_flow'; // binds a login to the browser that started it
+    const FLOW_TTL         = 600;
 
     const LOGIN_URL        = 'https://idp.trusona.com/authorizations/openid';
     const USERINFO_URL     = 'https://idp.trusona.com/openid/userinfo';
@@ -67,6 +70,8 @@ class TrusonaOpenID
     private $client_id;
     private $client_secret;
     private $redirect_url;
+    private $oidc_state;
+    private $oidc_nonce;
 
     public function __construct()
     {
@@ -76,6 +81,7 @@ class TrusonaOpenID
         do_action('trusona_openid_validate_registration');
 
         add_action('wp_logout', array($this, 'trusona_openid_logout'));
+        add_action('login_init', array($this, 'login_init'));
         add_action('login_footer', array($this, 'login_footer'));
         add_action('login_form', array(&$this, 'login_form'));
         add_action('login_enqueue_scripts', array(&$this, 'add_trusona_jquery'));
@@ -283,6 +289,22 @@ class TrusonaOpenID
             return;
         }
 
+        // Reject callbacks not bound to a login this browser started (login CSRF / replay).
+        $flow = $this->consume_oidc_flow();
+
+        if ($flow === null) {
+            $this->error_redirect(1);
+            return;
+        }
+
+        $returned_state = sanitize_text_field(wp_unslash($_GET['state']));
+        $returned_nonce = sanitize_text_field(wp_unslash($_GET['nonce']));
+
+        if (!hash_equals($flow['state'], $returned_state) || !hash_equals($flow['nonce'], $returned_nonce)) {
+            $this->error_redirect(1);
+            return;
+        }
+
         // Build redirect URI with nonce for token exchange
         $redirect_uri_with_nonce = add_query_arg('_wpnonce', sanitize_text_field(wp_unslash($_GET['_wpnonce'])), $this->redirect_url);
 
@@ -312,7 +334,7 @@ class TrusonaOpenID
         $id_token = $token_response['id_token'];
 
         if(isset($id_token)) {
-            if(!trusona_is_valid_jwt($id_token, $secret)) {
+            if(!trusona_is_valid_jwt($id_token, $secret, $flow['nonce'])) {
                 $this->error_redirect(10);
                 return;
             }
@@ -526,14 +548,95 @@ class TrusonaOpenID
         exit;
     }
 
+    // Runs before headers are sent, so the flow cookie can still be set.
+    public function login_init()
+    {
+        if ($this->trusona_enabled) {
+            $this->init_oidc_flow();
+        }
+    }
+
+    // Issue a state/nonce, store them server-side keyed by an opaque flow id,
+    // and put that id in an HttpOnly cookie. Idempotent within a request.
+    private function init_oidc_flow()
+    {
+        if (isset($this->oidc_state)) {
+            return;
+        }
+
+        $this->oidc_state = hash('ripemd160', random_bytes(64));
+        $this->oidc_nonce = hash('ripemd160', random_bytes(64));
+
+        $flow_id = bin2hex(random_bytes(16));
+
+        set_transient(
+            self::PLUGIN_ID_PREFIX . 'flow_' . $flow_id,
+            array('state' => $this->oidc_state, 'nonce' => $this->oidc_nonce),
+            self::FLOW_TTL
+        );
+
+        if (!headers_sent()) {
+            setcookie(self::FLOW_COOKIE, $flow_id, array(
+                'expires'  => time() + self::FLOW_TTL,
+                'path'     => '/',
+                'domain'   => defined('COOKIE_DOMAIN') ? COOKIE_DOMAIN : '',
+                'secure'   => is_ssl(),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ));
+        }
+    }
+
+    // Fetch and delete (single-use) the flow bound to the request's cookie.
+    // Returns null when there is no valid, unexpired flow.
+    private function consume_oidc_flow()
+    {
+        if (!isset($_COOKIE[self::FLOW_COOKIE])) {
+            return null;
+        }
+
+        $flow_id = sanitize_text_field(wp_unslash($_COOKIE[self::FLOW_COOKIE]));
+        $this->clear_oidc_flow_cookie();
+
+        if (!preg_match('/^[a-f0-9]{32}$/', $flow_id)) {
+            return null;
+        }
+
+        $key  = self::PLUGIN_ID_PREFIX . 'flow_' . $flow_id;
+        $flow = get_transient($key);
+        delete_transient($key); // single use
+
+        if (!is_array($flow) || !isset($flow['state'], $flow['nonce'])) {
+            return null;
+        }
+
+        return $flow;
+    }
+
+    private function clear_oidc_flow_cookie()
+    {
+        if (!headers_sent()) {
+            setcookie(self::FLOW_COOKIE, '', array(
+                'expires'  => time() - 3600,
+                'path'     => '/',
+                'domain'   => defined('COOKIE_DOMAIN') ? COOKIE_DOMAIN : '',
+                'secure'   => is_ssl(),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ));
+        }
+    }
+
     private function build_openid_url($redirect_url)
     {
+        $this->init_oidc_flow();
+
         // Add WordPress nonce to the redirect URL
         $wp_nonce = wp_create_nonce('trusona_openid_callback');
         $redirect_url_with_nonce = add_query_arg('_wpnonce', $wp_nonce, $redirect_url);
-        
-        return $this->login_url . '?state=' . hash('ripemd160', random_bytes(2048))
-               . '&nonce=' . hash('ripemd160', random_bytes(2048))
+
+        return $this->login_url . '?state=' . urlencode($this->oidc_state)
+               . '&nonce=' . urlencode($this->oidc_nonce)
                . '&scope=' . urlencode(self::SCOPES)
                . '&response_type=code&client_id=' . urlencode($this->client_id)
                . '&redirect_uri=' . urlencode($redirect_url_with_nonce);


### PR DESCRIPTION
## Summary

Fixes a **login CSRF / forced-authentication** weakness in the OpenID login flow. The OpenID `state` and `nonce` were generated and sent to the IdP but **never validated on the callback**, so the `state` parameter provided no CSRF protection. An attacker could complete the front channel with their own authorization `code` and deliver the callback URL to a logged-out victim, silently logging the victim's browser into the attacker's account. The anonymous `_wpnonce` did not mitigate this (logged-out WP nonces are not browser-specific).

## Changes

**Security**
- Issue a fresh `state`/`nonce` per login, stored server-side in a transient keyed by an opaque flow id, with that id bound to the browser via an **HttpOnly, `SameSite=Lax`, `Secure`-when-HTTPS cookie** set in `login_init` (before headers are sent).
- On callback, require a matching **single-use** flow and `hash_equals` the returned `state` and `nonce`; reject otherwise. A victim who never started a flow has no cookie, so the forced login is blocked.
- Validate the ID token `nonce` claim — `trusona_is_valid_jwt()` gained an optional `$expected_nonce` argument — closing the in-window replay gap.

**Maintenance**
- Removed the unused bundled `firebase/php-jwt` library (the plugin never `require`s its autoloader; validation is done by the plugin's own JWT functions).
- Repaired the unit test suite (stale function names, `ABSPATH` bootstrap), bumped PHPUnit to `^9.6` for PHP 8.1, and added coverage for nonce binding, wrong-secret, and malformed-token cases.
- Bumped version to **2.0.3** and updated `CHANGELOG.md` / `readme.txt`.

## Notes / follow-ups
- Minor UX trade-off: the flow cookie is last-write-wins, so opening the login page in two tabs and clicking the *older* tab's button is rejected (retry succeeds). Standard for browser-bound CSRF tokens.
- The cookie/transient flow logic is WordPress-coupled and would need a WP integration harness to unit-test end-to-end; the pure JWT/nonce validation is covered.
- Separate pre-existing gap worth confirming: `tmp/copy-to-svn.sh` / `upload-uat.sh` do not ship `js/`, yet the login JS lives in `js/trusona-login.js` since 2.0.0.

## Testing
Not executed in this environment (no PHP runtime). To run:
```
cd tests && composer install && cd ..
tests/vendor/bin/phpunit -c phpunit.xml
```

PR created by Claude